### PR TITLE
Add DBus connection health checks and improve service restart handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,11 @@
 
 ### Key Features
 1. **Video Recording Options** (via command-line flags):
-   - `-out`: Output directory (defaults to `~/Videos/screencapture`)
+   - `-out`: Output directory (defaults to `~/.cache/snoopy/video`)
    - `-segment`: Duration of each recording segment (default: 30 minutes)
    - `-pause`: Pause duration between segments (default: 1 second)
    - `-template`: Filename template for video files (default: `screen-%d-%t.webm`)
+   - `-health-check`: Interval for DBus connection health checks (default: `15s`)
 
 2. **Web Streaming Options**:
    - `-addr`: HTTP server bind address (default: `0.0.0.0`)
@@ -37,19 +38,49 @@
    - Automatic pruning to maintain cache size limit
    - Displays a "Waiting for next screen capture" placeholder on initial load
 
-5. **Error Resilience**: If a recording fails to start or stop, it logs the error and continues trying after a delay
+5. **Error Resilience**:
+   - If a recording fails to start or stop, it logs the error and continues trying after a delay
+   - Periodic DBus connection health checks (every 15 seconds by default) detect session pauses/locks
+   - When DBus connection is lost, the service exits cleanly with error code 1
+   - Prevents processing stale frames from closed video files during session interruptions
 
-6. **System Service**: Includes a systemd service file (`snoopy.service`) to run as a background service that automatically restarts on failure
+6. **System Service**:
+   - Includes a systemd service file (`snoopy.service`) to run as a background service
+   - Configured with `Restart=on-failure` to automatically restart when DBus connection is lost
+   - Gracefully recovers from session pause/lock events (screen lock, system suspend, etc.)
+   - Service automatically resumes recording when the user session becomes active again
+
+### DBus Connection Health Monitoring
+
+Snoopy includes robust connection monitoring to handle session interruptions gracefully:
+
+**Problem Solved**: Previously, when a user session was paused (screen lock, inactivity timeout, suspend), the DBus connection to GNOME Shell would be lost, but the service would continue running. This caused the ffmpeg frame extraction to process stale frames from closed video files.
+
+**Solution**:
+- **Periodic Health Checks**: Every 15 seconds (configurable), the service pings the DBus connection using `org.freedesktop.DBus.Peer.Ping`
+- **Connection Loss Detection**: If the ping fails, the service immediately detects the lost connection
+- **Clean Shutdown**: The service stops the screencast gracefully and exits with code 1
+- **Automatic Recovery**: systemd's `Restart=on-failure` configuration automatically restarts the service
+- **Fresh Start**: When the session resumes, a new service instance connects to DBus and starts recording fresh
+
+**Benefits**:
+- ✅ No stale frame processing during session pauses
+- ✅ Automatic recovery when session resumes
+- ✅ Clear logging of connection loss events
+- ✅ Configurable health check interval
+- ✅ Fast detection (within 15 seconds by default)
 
 ### Technical Details
 - Written in Go
 - Uses D-Bus to communicate with GNOME Shell's Screencast interface for video recording
+- Implements periodic DBus health checks via `org.freedesktop.DBus.Peer.Ping`
 - Extracts frames from recorded video files (MP4/WebM) using ffmpeg for web streaming
 - Outputs video files in MP4 or WebM format (GNOME Shell configurable)
 - Web streaming uses JPEG format for real-time compatibility
 - Built-in HTTP server with SSE support for real-time streaming
 - Advertises via Avahi with TXT records including `path=/` and `sse=/sse/image`
 - Designed to run as a user session service on Linux systems with GNOME
+- Exits with non-zero code on DBus connection loss for systemd restart
 
 ### Dependencies
 - **Required**: GNOME Shell with Screencast support (for video recording)

--- a/server/snoopy.service
+++ b/server/snoopy.service
@@ -6,7 +6,9 @@ Wants=graphical-session.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/snoopy -segment 30m -port 8900
-Restart=always
+# Restart on failure (non-zero exit code) such as when DBus connection is lost
+# This allows the service to recover from session pause/lock events
+Restart=on-failure
 RestartSec=2
 
 [Install]


### PR DESCRIPTION
## Summary
This PR adds periodic health checks for the DBus connection to detect when the session is paused or locked, and improves the systemd service configuration to properly handle connection loss scenarios.

## Key Changes
- **New `checkDBusConnection()` function**: Implements a health check by calling the standard DBus `Peer.Ping` method to verify the connection is still alive
- **Periodic health check loop**: Added a configurable ticker (default 15 seconds) that runs in the main event loop to detect connection loss
- **Enhanced error handling**: Added connection checks when segment rotation fails to distinguish between transient errors and actual connection loss
- **Improved service restart behavior**: Changed systemd service from `Restart=always` to `Restart=on-failure` so the service only restarts when it exits with a non-zero code, allowing graceful shutdowns to stay stopped
- **New CLI flag**: Added `--health-check` flag to configure the health check interval
- **Better logging**: Added informative log messages about health check status and connection loss scenarios

## Implementation Details
- The health check uses the standard DBus `org.freedesktop.DBus.Peer.Ping` interface, which is available on all DBus connections
- When connection loss is detected, the service attempts to stop the current screencast before exiting with code 1, triggering systemd to restart it
- The health check interval is configurable and defaults to 15 seconds, providing a reasonable balance between responsiveness and overhead
- Connection checks are also performed when segment rotation fails, helping diagnose whether failures are due to connection loss or other issues